### PR TITLE
Use checked() for sound checkbox.

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -71,8 +71,9 @@ function setup() {
             game.playFallSound = false;
             game.playMoveSound = false;
         }
-        playSound = !playSound;
+        playSound = dom.sound.checked();
     });
+    playSound = dom.sound.checked();
 
     resizeDOM();
     showGame(true);


### PR DESCRIPTION
On Firefox when I refresh the page it remembers the state of the "sound" checkbox, so this uses the "checked()" method instead of swapping the values.