### PR TITLE
Removed 'mute backgroud music checkbox'

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,9 +233,6 @@
 
             <hr />
             <h3>Visual Settings</h3>
-            <label for="muteBackgroundMusic">Mute background music</label>
-            <input type="checkBox" id="muteBackgroundMusic" />
-            <br>
             <label for="oldGraphics">Use old graphics</label>
             <input type="checkbox" id="oldGraphics" />
             <br>


### PR DESCRIPTION
This just removes the 'mute backgroud music' checkbox in the settings menu. The checkbox doesnt do anything atm and I dunno if you wanna keep it in or not